### PR TITLE
refine the slop to stop the slop from slopping the slop

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "wxt-starter",

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -82,10 +82,9 @@ function watchAndReplace(root: Node, replaces: ReplacerType[]) {
 
                 const prevText = text[offset - 1];
                 const afterText = text[offset + match.length];
-
+                const afterDot = text[offset + match.length + 1];
                 if (
-                    afterText === "." ||
-                    (prevText === "." && afterText === ".")
+                    (afterText === "." && afterDot && /[a-z0-9]/i.test(afterDot)) || (prevText === "." && afterText === ".")
                 ) {
                     return match;
                 }

--- a/replacers.ts
+++ b/replacers.ts
@@ -13,20 +13,32 @@ export const replacers = [
         enabled: true,
     },
     {
-        from: "Satya Nadella",
-        to: "Slopya Nuttela",
-        ignorePrefix: ["@", "#"],
-        enabled: true,
-    },
-    {
         from: "Satya Narayana Nadella",
         to: "Slopya Narayana Nuttela",
         ignorePrefix: ["@", "#"],
         enabled: true,
     },
     {
+        from: "Satya Nadella",
+        to: "Slopya Nuttela",
+        ignorePrefix: ["@", "#"],
+        enabled: true,
+    },
+    {
         from: "Artificial Intelligence",
         to: "Actually Indians",
+        ignorePrefix: ["@", "#"],
+        enabled: true,
+    },
+    {
+        from: "Satya",
+        to: "Slopya",
+        ignorePrefix: ["@", "#"],
+        enabled: true,
+    },
+    {
+        from: "Nadella",
+        to: "Nuttela",
         ignorePrefix: ["@", "#"],
         enabled: true,
     },


### PR DESCRIPTION
lol nice

anyways, just updated the dot detection to only ignore stuff that's followed by a dot that continues into
text (like domains), and also added an entry to the replacers for ``Nadella -> Nuttela``.

<img width="1277" height="662" alt="image" src="https://github.com/user-attachments/assets/f2476074-03ac-4eb9-9803-6145aba68ddf" />