### PR TITLE
Add new replacements for Microslop Office products

### DIFF
--- a/replacers.ts
+++ b/replacers.ts
@@ -78,4 +78,34 @@ export const replacers = [
         to: "DegenAI",
         ignorePrefix: ["@", "#"],
     },
+    {
+        from: "Excel",
+        to: "Exslop",
+        ignorePrefix: ["@", "#"],
+    },
+    {
+        from: "PowerPoint",
+        to: "PowerSlop",
+        ignorePrefix: ["@", "#"],
+    },
+    {
+        from: "OneNote",
+        to: "NoteSlop",
+        ignorePrefix: ["@", "#"],
+    },
+    {
+        from: "Outlook",
+        to: "Sloplook",
+        ignorePrefix: ["@", "#"],
+    },
+    {
+        from: "SharePoint",
+        to: "SlopPoint",
+        ignorePrefix: ["@", "#"],
+    },
+    {
+        from: "Access",
+        to: "Slopccess",
+        ignorePrefix: ["@", "#"],
+    },
 ] satisfies ReplacerType[];


### PR DESCRIPTION
Adds a few new replacements for Microsoft Office products.

Added replacements:
- Excel → Exslop
- PowerPoint → PowerSlop
- OneNote → NoteSlop
- Outlook → Sloplook
- SharePoint → SlopPoint
- Access → Slopccess